### PR TITLE
add unsafe actions

### DIFF
--- a/client.go
+++ b/client.go
@@ -40,7 +40,7 @@ func NewClient(gqlEndpoint string, opt *ClientOpts) *Client {
 	return c
 }
 
-func (c *Client) do(q Queryable) (*bytes.Buffer, error) {
+func (c *Client) Do(q Queryable) (*bytes.Buffer, error) {
 	reqObj := graphqlRequest{
 		Query:     q.Query(),
 		Variables: q.Variables(),

--- a/marshal_gql.go
+++ b/marshal_gql.go
@@ -1,16 +1,16 @@
 package eywa
 
-type gqlMarshaler interface {
-	marshalGQL() string
+type GQLMarshaler interface {
+	MarshalGQL() string
 }
 
 type HasuraEnum string
 
-func (he HasuraEnum) marshalGQL() string {
+func (he HasuraEnum) MarshalGQL() string {
 	_ = x(he)
 	return string(he)
 }
 
-func x(q gqlMarshaler) string {
+func x(q GQLMarshaler) string {
 	return "abcd"
 }

--- a/query_arg.go
+++ b/query_arg.go
@@ -15,7 +15,7 @@ type queryArgs[M Model, FN FieldName[M], F Field[M]] struct {
 	set        *set[M, F]
 }
 
-func (qa queryArgs[M, FN, F]) marshalGQL() string {
+func (qa queryArgs[M, FN, F]) MarshalGQL() string {
 	var args []string
 	args = appendArg(args, qa.limit)
 	args = appendArg(args, qa.offset)
@@ -31,7 +31,7 @@ func appendArg(arr []string, arg queryArg) []string {
 	if arg == nil || reflect.ValueOf(arg).IsNil() {
 		return arr
 	}
-	s := arg.marshalGQL()
+	s := arg.MarshalGQL()
 	if s == "" {
 		return arr
 	}
@@ -40,7 +40,7 @@ func appendArg(arr []string, arg queryArg) []string {
 
 type queryArg interface {
 	queryArgName() string
-	marshalGQL() string
+	MarshalGQL() string
 }
 
 type limit int
@@ -48,7 +48,7 @@ type limit int
 func (l limit) queryArgName() string {
 	return "limit"
 }
-func (l limit) marshalGQL() string {
+func (l limit) MarshalGQL() string {
 	return fmt.Sprintf("%s: %d", l.queryArgName(), l)
 }
 
@@ -57,7 +57,7 @@ type offset int
 func (o offset) queryArgName() string {
 	return "offset"
 }
-func (o offset) marshalGQL() string {
+func (o offset) MarshalGQL() string {
 	return fmt.Sprintf("%s: %d", o.queryArgName(), o)
 }
 
@@ -68,7 +68,7 @@ type distinctOn[M Model, FN FieldName[M]] struct {
 func (do distinctOn[M, FN]) queryArgName() string {
 	return "distinct_on"
 }
-func (do distinctOn[M, FN]) marshalGQL() string {
+func (do distinctOn[M, FN]) MarshalGQL() string {
 	return fmt.Sprintf("%s: %s", do.queryArgName(), do.field)
 }
 
@@ -79,8 +79,8 @@ type where struct {
 func (w where) queryArgName() string {
 	return "where"
 }
-func (w where) marshalGQL() string {
-	return fmt.Sprintf("%s: %s", w.queryArgName(), w.WhereExpr.marshalGQL())
+func (w where) MarshalGQL() string {
+	return fmt.Sprintf("%s: %s", w.queryArgName(), w.WhereExpr.MarshalGQL())
 }
 
 type set[M Model, F Field[M]] struct {
@@ -90,11 +90,11 @@ type set[M Model, F Field[M]] struct {
 func (s set[M, F]) queryArgName() string {
 	return "_set"
 }
-func (s set[M, F]) marshalGQL() string {
+func (s set[M, F]) MarshalGQL() string {
 	if s.fieldArr == nil || len(s.fieldArr) == 0 {
 		return ""
 	}
-	return fmt.Sprintf("%s: {%s}", s.queryArgName(), s.fieldArr.marshalGQL())
+	return fmt.Sprintf("%s: {%s}", s.queryArgName(), s.fieldArr.MarshalGQL())
 }
 
 type operator string
@@ -165,10 +165,10 @@ type WhereExpr struct {
 
 type whereArr []*WhereExpr
 
-func (wa whereArr) marshalGQL() string {
+func (wa whereArr) MarshalGQL() string {
 	stringArr := make([]string, 0, len(wa))
 	for _, whereExpr := range wa {
-		expr := whereExpr.marshalGQL()
+		expr := whereExpr.MarshalGQL()
 		if expr != "" {
 			stringArr = append(stringArr, expr)
 		}
@@ -176,7 +176,7 @@ func (wa whereArr) marshalGQL() string {
 	return strings.Join(stringArr, ", ")
 }
 
-func (w *WhereExpr) marshalGQL() string {
+func (w *WhereExpr) MarshalGQL() string {
 	if w == nil {
 		return ""
 	}
@@ -185,17 +185,17 @@ func (w *WhereExpr) marshalGQL() string {
 	}
 	var stringArr []string
 
-	andExpr := w.and.marshalGQL()
+	andExpr := w.and.MarshalGQL()
 	if andExpr != "" {
 		stringArr = append(stringArr, fmt.Sprintf("_and: [%s]", andExpr))
 	}
 
-	orExpr := w.or.marshalGQL()
+	orExpr := w.or.MarshalGQL()
 	if orExpr != "" {
 		stringArr = append(stringArr, fmt.Sprintf("_or: [%s]", orExpr))
 	}
 
-	notExpr := w.not.marshalGQL()
+	notExpr := w.not.MarshalGQL()
 	if notExpr != "" {
 		stringArr = append(stringArr, fmt.Sprintf("_not: %s", notExpr))
 	}
@@ -212,7 +212,7 @@ type OrderByExpr struct {
 	field string
 }
 
-func (ob OrderByExpr) marshalGQL() string {
+func (ob OrderByExpr) MarshalGQL() string {
 	return fmt.Sprintf("%s: %s", ob.field, ob.order)
 }
 
@@ -241,13 +241,13 @@ func (oba orderBy) queryArgName() string {
 	return "order_by"
 }
 
-func (oba orderBy) marshalGQL() string {
+func (oba orderBy) MarshalGQL() string {
 	if len(oba) == 0 {
 		return ""
 	}
 	stringArr := make([]string, 0, len(oba))
 	for _, ob := range oba {
-		expr := ob.marshalGQL()
+		expr := ob.MarshalGQL()
 		if expr != "" {
 			stringArr = append(stringArr, expr)
 		}

--- a/query_vars.go
+++ b/query_vars.go
@@ -10,13 +10,13 @@ type queryVar struct {
 	value TypedValue
 }
 
-func (v queryVar) marshalGQL() string {
+func (v queryVar) MarshalGQL() string {
 	return fmt.Sprintf("$%s: %s", v.name, v.value.Type())
 }
 
 type queryVarArr []queryVar
 
-func (vs queryVarArr) marshalGQL() string {
+func (vs queryVarArr) MarshalGQL() string {
 	if len(vs) == 0 {
 		return ""
 	}
@@ -25,7 +25,7 @@ func (vs queryVarArr) marshalGQL() string {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		buf.WriteString(v.marshalGQL())
+		buf.WriteString(v.MarshalGQL())
 	}
 	buf.WriteString(")")
 	return buf.String()

--- a/unsafe/actions.go
+++ b/unsafe/actions.go
@@ -1,0 +1,121 @@
+package unsafe
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/imperfect-fourth/eywa"
+)
+
+type ActionQueryBuilder[M eywa.Model] struct {
+	ModelName string
+	queryArgs map[string]interface{}
+}
+
+func Action[M eywa.Model, MP eywa.ModelPtr[M]]() ActionQueryBuilder[M] {
+	return ActionQueryBuilder[M]{
+		ModelName: (*new(M)).ModelName(),
+	}
+}
+
+func (aq ActionQueryBuilder[M]) MarshalGQL() string {
+	buf := bytes.NewBuffer([]byte{})
+	first := true
+	for k, v := range aq.queryArgs {
+		if !first {
+			buf.WriteString(", ")
+		} else {
+			first = false
+		}
+		buf.WriteString(k)
+		buf.WriteString(": ")
+		if val, ok := v.(eywa.GQLMarshaler); ok {
+			buf.WriteString(val.MarshalGQL())
+		} else {
+			val, _ := json.Marshal(v)
+			vt := reflect.TypeOf(v)
+			if vt.Kind() == reflect.Ptr {
+				vt = vt.Elem()
+			}
+			if vt.Kind() == reflect.Struct || vt.Kind() == reflect.Map {
+				val, _ = json.Marshal(string(val))
+			}
+			buf.WriteString(string(val))
+		}
+	}
+
+	s := buf.String()
+	if s == "" {
+		return aq.ModelName
+	}
+	return fmt.Sprintf("%s(%s)", aq.ModelName, s)
+}
+
+func (aq ActionQueryBuilder[M]) QueryArgs(args map[string]interface{}) ActionQueryBuilder[M] {
+	aq.queryArgs = args
+	return aq
+}
+
+func (aq ActionQueryBuilder[M]) Select(field string, fields ...string) ActionQuery[M] {
+	return ActionQuery[M]{
+		aq:     &aq,
+		fields: append(fields, field),
+	}
+}
+
+type ActionQuery[M eywa.Model] struct {
+	aq     *ActionQueryBuilder[M]
+	fields []string
+}
+
+func (aq ActionQuery[M]) MarshalGQL() string {
+	return fmt.Sprintf(
+		"%s {\n%s\n}",
+		aq.aq.MarshalGQL(),
+		strings.Join(aq.fields, "\n"),
+	)
+}
+
+func (aq ActionQuery[M]) Query() string {
+	return fmt.Sprintf(
+		"query run_%s {\n%s\n}",
+		aq.aq.ModelName,
+		aq.MarshalGQL(),
+	)
+}
+
+func (aq ActionQuery[M]) Variables() map[string]interface{} {
+	return nil
+}
+
+func (aq ActionQuery[M]) Exec(client *eywa.Client) (*M, error) {
+	respBytes, err := client.Do(aq)
+	if err != nil {
+		return nil, err
+	}
+
+	type graphqlResponse struct {
+		Data   map[string]*M       `json:"data"`
+		Errors []eywa.GraphQLError `json:"errors"`
+	}
+
+	respObj := graphqlResponse{}
+	err = json.NewDecoder(respBytes).Decode(&respObj)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(respObj.Errors) > 0 {
+		gqlErrs := make([]error, 0, len(respObj.Errors))
+		for _, e := range respObj.Errors {
+			gqlErrs = append(gqlErrs, errors.New(e.Message))
+		}
+		return nil, errors.Join(gqlErrs...)
+	}
+
+	return respObj.Data[aq.aq.ModelName], nil
+}

--- a/unsafe/actions_test.go
+++ b/unsafe/actions_test.go
@@ -1,0 +1,35 @@
+// nolint
+package unsafe
+
+import (
+	"testing"
+
+	"github.com/imperfect-fourth/eywa"
+	"github.com/stretchr/testify/assert"
+)
+
+type testAction struct {
+	Name string `json:"name"`
+	ID   *int   `json:"id,omitempty"`
+}
+
+func (a testAction) ModelName() string {
+	return "test_action"
+}
+
+func TestActionQuery(t *testing.T) {
+	q := Action[testAction]().QueryArgs(
+		map[string]interface{}{
+			"arg1": 4,
+			"arg2": "value",
+			"arg3": eywa.HasuraEnum("enumvalue"),
+		},
+	).Select("name")
+
+	expected := `query run_test_action {
+test_action(arg1: 4, arg2: "value", arg3: enumvalue) {
+name
+}
+}`
+	assert.Equal(t, expected, q.Query())
+}

--- a/update.go
+++ b/update.go
@@ -33,13 +33,13 @@ func (uq UpdateQueryBuilder[M, FN, F]) Where(w *WhereExpr) UpdateQueryBuilder[M,
 	return uq
 }
 
-func (uq *UpdateQueryBuilder[M, FN, F]) marshalGQL() string {
+func (uq *UpdateQueryBuilder[M, FN, F]) MarshalGQL() string {
 	if uq.where == nil {
 		uq.where = &where{Not(&WhereExpr{})}
 	}
 	return fmt.Sprintf(
 		"update_%s",
-		uq.QuerySkeleton.marshalGQL(),
+		uq.QuerySkeleton.MarshalGQL(),
 	)
 }
 
@@ -55,11 +55,11 @@ type UpdateQuery[M Model, FN FieldName[M], F Field[M]] struct {
 	fields []FN
 }
 
-func (uq UpdateQuery[M, FN, F]) marshalGQL() string {
+func (uq UpdateQuery[M, FN, F]) MarshalGQL() string {
 	return fmt.Sprintf(
 		"%s {\nreturning {\n%s\n}\n}",
-		uq.uq.marshalGQL(),
-		FieldNameArr[M, FN](uq.fields).marshalGQL(),
+		uq.uq.MarshalGQL(),
+		FieldNameArr[M, FN](uq.fields).MarshalGQL(),
 	)
 }
 
@@ -67,8 +67,8 @@ func (uq UpdateQuery[M, FN, F]) Query() string {
 	return fmt.Sprintf(
 		"mutation update_%s%s {\n%s\n}",
 		uq.uq.ModelName,
-		uq.uq.queryVars.marshalGQL(),
-		uq.marshalGQL(),
+		uq.uq.queryVars.MarshalGQL(),
+		uq.MarshalGQL(),
 	)
 }
 
@@ -81,7 +81,7 @@ func (uq UpdateQuery[M, FN, F]) Variables() map[string]interface{} {
 }
 
 func (uq UpdateQuery[M, FN, F]) Exec(client *Client) ([]M, error) {
-	respBytes, err := client.do(uq)
+	respBytes, err := client.Do(uq)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (uq UpdateQuery[M, FN, F]) Exec(client *Client) ([]M, error) {
 	}
 	type graphqlResponse struct {
 		Data   map[string]mutationReturning `json:"data"`
-		Errors []graphqlError               `json:"errors"`
+		Errors []GraphQLError               `json:"errors"`
 	}
 
 	respObj := graphqlResponse{}


### PR DESCRIPTION
Example:
```go
type testAction struct {
	Name string `json:"name"`
	ID   *int   `json:"id,omitempty"`
}

func (a testAction) ModelName() string {
	return "test_action"
}

...

q := Action[testAction]().QueryArgs(
	map[string]interface{}{
		"arg1": 4,
		"arg2": "value",
		"arg3": eywa.HasuraEnum("enumvalue"),
	},
).Select("name").Exec(client)

```